### PR TITLE
ExcelファイルやJsonファイルに対応するデータがない場合の処理を追加。

### DIFF
--- a/Assets/Resources/MasterData/SenarioSO.asset
+++ b/Assets/Resources/MasterData/SenarioSO.asset
@@ -16,39 +16,43 @@ MonoBehaviour:
     senario:
     - senarioNo: 0
       messageString: "\u3042\u3044\u3046\u3048\u304A,\u304B\u304D\u304F\u3051\u3053"
-      charaNoString: 1,2
+      charaNoString: 
       branchString: -1
       displayCharaString: 3/0,1
       backgroundImageNo: 0
       bgmNo: 0
       branchMessageString: 123,aaa
       autoScenarioNo: 1
+      endingNo: 0
       messages:
       - "\u3042\u3044\u3046\u3048\u304A"
       - "\u304B\u304D\u304F\u3051\u3053"
-      charaTypes: 0100000002000000
+      charaTypes: 
       branchs: ffffffff
       branchMessages:
       - 123
       - aaa
+      conditionalBranchNo: 
     - senarioNo: 1
       messageString: "\u3055\u3057\u3059\u305B\u305D\n\u306A\u306B\u306C\u306D\u306E,\u305F\u3061\u3064\u3066\u3068"
       charaNoString: 0,1
-      branchString: 0,1,2
+      branchString: 5/1/0,1,2
       displayCharaString: 0,2/1
       backgroundImageNo: 1
       bgmNo: 0
       branchMessageString: fff,ddd,kkk
       autoScenarioNo: 0
+      endingNo: 1
       messages:
       - "\u3055\u3057\u3059\u305B\u305D\n\u306A\u306B\u306C\u306D\u306E"
       - "\u305F\u3061\u3064\u3066\u3068"
       charaTypes: 0000000001000000
-      branchs: 000000000100000002000000
+      branchs: 010000000100000002000000
       branchMessages:
       - fff
       - ddd
       - kkk
+      conditionalBranchNo: 05000000
     - senarioNo: 2
       messageString: "\u308F\u3092\u3093"
       charaNoString: 2,3
@@ -58,9 +62,11 @@ MonoBehaviour:
       bgmNo: 0
       branchMessageString: gggg
       autoScenarioNo: 0
+      endingNo: 0
       messages:
       - "\u308F\u3092\u3093"
       charaTypes: 0200000003000000
       branchs: 00000000
       branchMessages:
       - gggg
+      conditionalBranchNo: 

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -142,7 +142,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &392799509
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameData.cs
+++ b/Assets/Scripts/GameData.cs
@@ -55,10 +55,14 @@ public class GameData : MonoBehaviour
         scenarioSO.senarioMasterData = LoadMasterDataFromJson.LoadSenarioMasterDataFromJson();
 
         // 文字列を適宜な型に変換して配列に代入
-        foreach (SenarioMasterData.SenarioData senarioData in scenarioSO.senarioMasterData.senario) {
+        foreach (SenarioMasterData.SenarioData senarioData in scenarioSO.senarioMasterData.senario) {            
             senarioData.messages = senarioData.messageString.Split(',').ToArray();
-            senarioData.charaTypes = senarioData.charaNoString.Split(',').Select(x => (CHARA_NAME_TYPE)Enum.Parse(typeof(CHARA_NAME_TYPE), x)).ToArray();
-            
+
+            // キャラ表示する場合
+            if (!string.IsNullOrEmpty(senarioData.charaNoString)) {
+                senarioData.charaTypes = senarioData.charaNoString.Split(',').Select(x => (CHARA_NAME_TYPE)Enum.Parse(typeof(CHARA_NAME_TYPE), x)).ToArray();
+            }
+
             // 分岐番号の文字列をカンマ位置で分割して配列に代入
             string[] tempBranchNos = senarioData.branchString.Split(',').ToArray();
 
@@ -78,21 +82,28 @@ public class GameData : MonoBehaviour
                     // 条件のない通常の分岐はそのまま配列に代入
                     senarioData.branchs[x] = int.Parse(tempBranchNos[x]); 
                 }
-            } 
-  
+            }
+
             // 今までの分岐番号の代入は不要になる
             //senarioData.branchs = senarioData.branchString.Split(',').Select(x => int.Parse(x)).ToArray();
 
-            senarioData.branchMessages = senarioData.branchMessageString.Split(',').ToArray(); // 追加。分岐メッセージを配列にする
+            // 分岐がある場合
+            if (!string.IsNullOrEmpty(senarioData.branchMessageString)) {
+                // 分岐メッセージを配列にする
+                senarioData.branchMessages = senarioData.branchMessageString.Split(',').ToArray(); 
+            }
 
-            List<string> strList = senarioData.displayCharaString.Split('/').ToList();
+            // 表示するキャラがいる場合
+            if (!string.IsNullOrEmpty(senarioData.displayCharaString)) {
+                List<string> strList = senarioData.displayCharaString.Split('/').ToList();
 
-            int i = 0;
-            senarioData.displayCharas = new Dictionary<int, CHARA_NAME_TYPE[]>();
-            foreach (string str in strList) {
-                CHARA_NAME_TYPE[] displayChara = str.Split(',').Select(x => (CHARA_NAME_TYPE)Enum.Parse(typeof(CHARA_NAME_TYPE), x)).ToArray();
-                senarioData.displayCharas.Add(i, displayChara);
-                i++;
+                int i = 0;
+                senarioData.displayCharas = new Dictionary<int, CHARA_NAME_TYPE[]>();
+                foreach (string str in strList) {
+                    CHARA_NAME_TYPE[] displayChara = str.Split(',').Select(x => (CHARA_NAME_TYPE)Enum.Parse(typeof(CHARA_NAME_TYPE), x)).ToArray();
+                    senarioData.displayCharas.Add(i, displayChara);
+                    i++;
+                }
             }
         }
         Debug.Log("Create SenarioDataList");

--- a/Assets/Scripts/SoundManager.cs
+++ b/Assets/Scripts/SoundManager.cs
@@ -26,6 +26,7 @@ public class SoundManager : MonoBehaviour {
     public enum BGM_Type : int {
         TITLE,
         MAIN,
+        NO_MUSIC = 999,
     }
 
     // 効果音管理(適宜追加する)
@@ -83,6 +84,12 @@ public class SoundManager : MonoBehaviour {
     /// <param name="bgmNo"></param>
     /// <param name="loopFlg"></param>
     public void PlayBGM(BGM_Type bgmNo, bool loopFlg = true) {
+        // BGMなしの場合
+        if ((int)bgmNo == 999) {
+            StopAllBGM();
+            return;
+        }
+
         int index = (int)bgmNo;
         currentBgmIndex = index;
 


### PR DESCRIPTION
・シナリオデータをExcelファイルやJsonファイルから読み込む際に、特定のシナリオ内に表示するキャラがいない場合にはキャラの読み込みでエラーにならないように修正。
・同じく、分岐がない場合には分岐メッセージの読み込みでエラーにならないように修正。
・同じく、BGMがない場合にはBGMを無音にするように修正。
・デバッグ完了。